### PR TITLE
use double values to prevent parsing errors in perfsig plugin

### DIFF
--- a/monspec/shipping_perfsig.json
+++ b/monspec/shipping_perfsig.json
@@ -4,15 +4,15 @@
             "timeseriesId" : "com.dynatrace.builtin:service.responsetime",
             "aggregation" : "avg",
             "tags" : "app:shipping,environment:dev",
-            "upperLimit" : 3000,
-            "lowerLimit" : 2800
+            "upperLimit" : 3000.0,
+            "lowerLimit" : 2800.0
         },
         {
             "timeseriesId" : "com.dynatrace.builtin:service.failurerate",
             "aggregation" : "avg",
             "tags" : "app:shipping,environment:dev",
-            "upperLimit" : 5,
-            "lowerLimit" : 0
+            "upperLimit" : 5.0,
+            "lowerLimit" : 0.0
         }
     ]
 }


### PR DESCRIPTION
- Read the contribution guidelines
- Include a reference to a related issue in this repository
- A description of the changes proposed in the pull request